### PR TITLE
fix sed handling in macOS

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -38,7 +38,7 @@ write_secrets() {
         return 1
     fi
 
-    echo "Wrote secrets to $(basename "$env_file") and saved backup to $(basename "$env_file").backup"
+    echo "Wrote secrets to $(basename "$env_file")"
 }
 
 generate_secrets() {
@@ -91,6 +91,12 @@ generate_secrets() {
             echo "Skipped writing secrets. You may want to add them manually to $(basename "$env_file")"
             ;;
         * )
+            if ! cp "$env_file" "$env_file.backup"; then
+                echo "Failed to backup $(basename "$env_file")"
+                return 1
+            fi
+            echo "Wrote backup to $(basename "$env_file").backup"
+
             echo "Overwriting secrets in $(basename "$env_file")"
             if ! write_secrets "$env_file"; then
                 return 1

--- a/lib.sh
+++ b/lib.sh
@@ -35,11 +35,18 @@ generate_secrets() {
     echo COORDINATOR_SECRET="$COORDINATOR_SECRET"
 
     write_secrets() {
-        sed -i "s/MAGIC_LINK_SECRET=.*/MAGIC_LINK_SECRET=$MAGIC_LINK_SECRET/" "$env_file"
-        sed -i "s/SESSION_SECRET=.*/SESSION_SECRET=$SESSION_SECRET/" "$env_file"
-        sed -i "s/ENCRYPTION_KEY=.*/ENCRYPTION_KEY=$ENCRYPTION_KEY/" "$env_file"
-        sed -i "s/PROVIDER_SECRET=.*/PROVIDER_SECRET=$PROVIDER_SECRET/" "$env_file"
-        sed -i "s/COORDINATOR_SECRET=.*/COORDINATOR_SECRET=$COORDINATOR_SECRET/" "$env_file"
+        sed -i '' "s|^MAGIC_LINK_SECRET=.*|MAGIC_LINK_SECRET=$MAGIC_LINK_SECRET|" "$env_file"
+        sed -i '' "s|^SESSION_SECRET=.*|SESSION_SECRET=$SESSION_SECRET|" "$env_file"
+        sed -i '' "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$ENCRYPTION_KEY|" "$env_file"
+        sed -i '' "s|^PROVIDER_SECRET=.*|PROVIDER_SECRET=$PROVIDER_SECRET|" "$env_file"
+        sed -i '' "s|^COORDINATOR_SECRET=.*|COORDINATOR_SECRET=$COORDINATOR_SECRET|" "$env_file"
+
+        if [ $? -eq 0 ]; then
+            echo "Successfully updated secrets in $env_file"
+        else
+            echo "Error updating secrets. Check if $env_file exists and is writable."
+            return 1
+        fi
     }
 
     if [ -z "$env_file" ]; then

--- a/lib.sh
+++ b/lib.sh
@@ -62,6 +62,7 @@ generate_secrets() {
 
     COORDINATOR_SECRET=$(openssl rand -hex 32)
     echo COORDINATOR_SECRET="$COORDINATOR_SECRET"
+
     if [ -z "$env_file" ]; then
         return
     fi
@@ -69,31 +70,31 @@ generate_secrets() {
     if [ ! -f "$env_file" ]; then
         read -p "No $(basename "$env_file") file found, would you like to create one? [Y/n] " yn
         case $yn in
-        [nN]*)
-            echo "Skipping .env file creation."
-            return
-            ;;
-        *)
-            env_example_file=$(dirname "$env_file")/.env.example
-            cp -v "$env_example_file" "$env_file"
+            [nN]* )
+                echo "Skipping .env file creation."
+                return
+                ;;
+            * )
+                env_example_file=$(dirname "$env_file")/.env.example
+                cp -v "$env_example_file" "$env_file"
 
-            echo "Writing secrets to $(basename "$env_file")"
-            write_secrets "$env_file"
-            ;;
+                echo "Writing secrets to $(basename "$env_file")"
+                write_secrets "$env_file"
+                ;;
         esac
     fi
 
     read -p "Would you like to replace your current secrets in $(basename "$env_file")? [Y/n] " yn
 
     case $yn in
-    [nN]*)
-        echo "Skipped writing secrets. You may want to add them manually to $(basename "$env_file")"
-        ;;
-    *)
-        echo "Overwriting secrets in $(basename "$env_file")"
-        cp -v "$env_file" "$env_file.backup"
-        write_secrets "$env_file"
-        echo "Done. Backup written to: $(basename "$env_file").backup"
-        ;;
+        [nN]* )
+            echo "Skipped writing secrets. You may want to add them manually to $(basename "$env_file")"
+            ;;
+        * )
+            echo "Overwriting secrets in $(basename "$env_file")"
+            cp -v "$env_file" "$env_file.backup"
+            write_secrets "$env_file"
+            echo "Done. Backup written to: $(basename "$env_file").backup"
+            ;;
     esac
 }

--- a/lib.sh
+++ b/lib.sh
@@ -97,5 +97,3 @@ generate_secrets() {
         ;;
     esac
 }
-
-generate_secrets ".env"

--- a/lib.sh
+++ b/lib.sh
@@ -14,11 +14,40 @@ docker_compose() {
     set +x
 }
 
+write_secrets() {
+    env_file=$1
+
+    # Determine the sed in-place flag based on the operating system
+    if [ "$(uname)" = "Darwin" ]; then
+        sed_cmd() {
+            sed -i '' "$@"
+        }
+    else
+        sed_cmd() {
+            sed -i "$@"
+        }
+    fi
+
+    # Based on the Operating System, use the appropriate sed command for each secret
+    sed_cmd "s|^MAGIC_LINK_SECRET=.*|MAGIC_LINK_SECRET=$MAGIC_LINK_SECRET|" "$env_file"
+    sed_cmd "s|^SESSION_SECRET=.*|SESSION_SECRET=$SESSION_SECRET|" "$env_file"
+    sed_cmd "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$ENCRYPTION_KEY|" "$env_file"
+    sed_cmd "s|^PROVIDER_SECRET=.*|PROVIDER_SECRET=$PROVIDER_SECRET|" "$env_file"
+    sed_cmd "s|^COORDINATOR_SECRET=.*|COORDINATOR_SECRET=$COORDINATOR_SECRET|" "$env_file"
+
+    if [ $? -eq 0 ]; then
+        echo "Successfully updated secrets in $env_file"
+    else
+        echo "Error updating secrets. Check if $env_file exists and is writable."
+        return 1
+    fi
+}
+
 generate_secrets() {
     env_file=$1
 
     echo "Generated secrets:"
-    
+
     MAGIC_LINK_SECRET=$(openssl rand -hex 16)
     echo MAGIC_LINK_SECRET="$MAGIC_LINK_SECRET"
 
@@ -33,22 +62,6 @@ generate_secrets() {
 
     COORDINATOR_SECRET=$(openssl rand -hex 32)
     echo COORDINATOR_SECRET="$COORDINATOR_SECRET"
-
-    write_secrets() {
-        sed -i '' "s|^MAGIC_LINK_SECRET=.*|MAGIC_LINK_SECRET=$MAGIC_LINK_SECRET|" "$env_file"
-        sed -i '' "s|^SESSION_SECRET=.*|SESSION_SECRET=$SESSION_SECRET|" "$env_file"
-        sed -i '' "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$ENCRYPTION_KEY|" "$env_file"
-        sed -i '' "s|^PROVIDER_SECRET=.*|PROVIDER_SECRET=$PROVIDER_SECRET|" "$env_file"
-        sed -i '' "s|^COORDINATOR_SECRET=.*|COORDINATOR_SECRET=$COORDINATOR_SECRET|" "$env_file"
-
-        if [ $? -eq 0 ]; then
-            echo "Successfully updated secrets in $env_file"
-        else
-            echo "Error updating secrets. Check if $env_file exists and is writable."
-            return 1
-        fi
-    }
-
     if [ -z "$env_file" ]; then
         return
     fi
@@ -56,33 +69,33 @@ generate_secrets() {
     if [ ! -f "$env_file" ]; then
         read -p "No $(basename "$env_file") file found, would you like to create one? [Y/n] " yn
         case $yn in
-            [nN]* )
-                echo "Skipping .env file creation."
-                return
-                ;;
-            * )
-                env_example_file=$(dirname "$env_file")/.env.example
-                cp -v "$env_example_file" "$env_file"
-                
-                echo "Writing secrets to $(basename "$env_file")"
-                write_secrets
-                ;;
+        [nN]*)
+            echo "Skipping .env file creation."
+            return
+            ;;
+        *)
+            env_example_file=$(dirname "$env_file")/.env.example
+            cp -v "$env_example_file" "$env_file"
+
+            echo "Writing secrets to $(basename "$env_file")"
+            write_secrets "$env_file"
+            ;;
         esac
     fi
 
     read -p "Would you like to replace your current secrets in $(basename "$env_file")? [Y/n] " yn
 
     case $yn in
-        [nN]* )
-            echo "Skipped writing secrets. You may want to add them manually to $(basename "$env_file")"
-            ;;
-        * )
-            echo "Overwriting secrets in $(basename "$env_file")"
-            cp -v "$env_file" "$env_file.backup"
-            write_secrets
-            echo "Done. Backup written to: $(basename "$env_file").backup"
-            ;;
+    [nN]*)
+        echo "Skipped writing secrets. You may want to add them manually to $(basename "$env_file")"
+        ;;
+    *)
+        echo "Overwriting secrets in $(basename "$env_file")"
+        cp -v "$env_file" "$env_file.backup"
+        write_secrets "$env_file"
+        echo "Done. Backup written to: $(basename "$env_file").backup"
+        ;;
     esac
-
-
 }
+
+generate_secrets ".env"

--- a/start.sh
+++ b/start.sh
@@ -36,7 +36,10 @@ if [ ! -f "$env_file" ]; then
                     echo "Skipping secret generation. You should really not skip this step."
                     ;;
                 * )
-                    generate_secrets "$env_file"
+                    if ! generate_secrets "$env_file"; then
+                        echo "Failed to generate secrets. Exiting."
+                        exit 1
+                    fi
                     sleep 2
                     ;;
             esac


### PR DESCRIPTION
### Why this PR?

This PR does two different things.
- Moves the `write_secrets` function outside of `generate_secrets` to avoid nested functions. 
- Handling of sed across Unix/Linux operating systems.

### Desc
sed behaves differently on GNU and macOS. 

The —i '' syntax correctly tells macOS's sed not to create a backup, which is the required form. The script also uses | as a delimiter for the sed substitution, which can sometimes make the script more readable and avoid conflicts with / characters in paths or values.

### Test
Tested on macos sequoia 15.0.1 (24A348) & Linux Ubuntu 6.8.0-45-generic (Ubuntu 22.04)

Resolves #6